### PR TITLE
Fixes E2E failures for Pad Op

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2160,8 +2160,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         }
 
         // The torch.pad op expects a different arrangement of padding pairs for
-        // each dimension as compared to the onnx.pad op. Rearrange the pad tensor
-        // as shown below:
+        // each dimension as compared to the onnx.pad op. Rearrange the pad
+        // tensor as shown below:
         //
         // [x1_begin, x2_begin, ..., x1_end, x2_end,...] ->
         // [xn_begin, xn_end, ...., x2_begin, x2_end, x1_begin, x1_end]

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -3662,7 +3662,9 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
     return DenseElementsAttr::get(outType.toBuiltinTensor(), values);
   }
 
-  // If the input and output shapes are the same we can just fold:
+  // If the input and output shapes are the same & step == 1 we can fold:
+  if (step.getValue().getSExtValue() != 1)
+    return nullptr;
   for (size_t i = 0; i < inType.getSizes().size(); ++i) {
     if (inType.getSizes()[i] != outType.getSizes()[i])
       return nullptr;


### PR DESCRIPTION
Hey. The pad issue was blocking my progress so I dug into it a bit and found out it was caused by a bad folder for AtenSliceTensorOp (it was folding this op even when the ordering was supposed to reverse). 

Please consider pulling this in and syncing your branch so we can merge your work.